### PR TITLE
Add the ability to override Element attributes.

### DIFF
--- a/src/Xml/Element.php
+++ b/src/Xml/Element.php
@@ -92,6 +92,15 @@ class Element implements ElementInterface {
   /**
    * {@inheritDoc}
    */
+  public function setElementAttributes(array $attributes) {
+    $this->attributes = $attributes;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public function addElementAttribute(AttributeInterface $attribute) {
     $this->attributes[] = $attribute;
 

--- a/src/Xml/ElementInterface.php
+++ b/src/Xml/ElementInterface.php
@@ -18,6 +18,17 @@ interface ElementInterface {
   public function getElementAttributes();
 
   /**
+   * Sets element attributes.
+   *
+   * @param array $attributes
+   *   An array with attribute elements.
+   *
+   * @return \Drupal\yandex_yml\Xml\ElementInterface
+   *   The current instance of element.
+   */
+  public function setElementAttributes(array $attributes);
+
+  /**
    * Adds attribute for element.
    *
    * @param \Drupal\yandex_yml\Xml\AttributeInterface $attribute


### PR DESCRIPTION
Столкнулся с проблемой - если для `OfferSimple` объекта уже задан атрибут `avilable`, перезаписать его значение после этого уже нельзя.

Проблема была решена добавлением возможности перезаписывать атрибуты элементов.